### PR TITLE
feat: Sync keymap with KLCM source of truth - Remove Studio dependencies

### DIFF
--- a/config/adv_mod.keymap
+++ b/config/adv_mod.keymap
@@ -6,15 +6,13 @@
  * ZMK keymap for Kinesis Advantage keyboards using Pillz Mod + Nice!Nano
  * Compatible with KLCM (Keyboard Layout Config Mapper)
  * 
- * This file serves as the KLCM configuration template. The actual ZMK shield 
- * keymap is located in boards/shields/pillzmod-nicenano/pillzmod-nicenano.keymap
- * 
+ * Hardware: Kinesis Advantage with Pillz Mod Pro + Nice!Nano v2
  * Repository: https://github.com/masters3d/zmk-config-pillzmod-nicenano
+ * Branch: cheyo
  */
 
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/backlight.h>
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/outputs.h>
 
@@ -68,13 +66,12 @@
                                                       &kp LCTRL  &kp LALT                                               &kp RGUI  &kp RCTRL
                                                                  &kp HOME                                               &kp PG_UP
                                         &kp BSPC   &kp DELETE  &kp END                                                &kp PG_DN  &kp ENTER &kp SPACE
-    &kp ESCAPE  &kp ESCAPE  &kp ESCAPE
             >;
         };
         
         keypad_layer {
             // -----------------------------------------------------------------------------------------
-            // Keypad/Numpad layer
+            // Keypad/Numpad layer - Toggle layer for numeric keypad functionality
             bindings = <
     &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans                          &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans
     &trans  &trans  &trans  &trans  &trans  &trans                                                                   &trans  &kp LOCKING_NUM   &kp KP_EQUAL  &kp KP_SLASH  &kp KP_ASTERISK  &trans
@@ -85,15 +82,15 @@
                                                   &trans  &trans                                        &trans  &trans
                                                           &trans                                        &trans
                                           &trans  &trans  &trans                                        &trans  &trans  &kp KP_N0
-    &trans  &trans  &trans
             >;
         };
 
         system_layer {
             // -----------------------------------------------------------------------------------------
-            // System layer: Bluetooth, backlight, bootloader
+            // System layer: Bluetooth, output selection, bootloader access
+            // No ZMK Studio features - clean, compatible implementation
             bindings = <
-    &studio_unlock  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &trans  &trans  &trans  &trans       &bt BT_CLR  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans
+    &trans  &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &trans  &trans  &trans  &trans       &bt BT_CLR  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans
     &trans  &trans  &trans  &trans  &trans  &trans                                                                   &trans  &trans  &trans  &trans  &trans  &bootloader
     &trans  &trans  &trans  &trans  &trans  &trans                                                                   &trans  &trans  &trans  &trans  &trans  &trans
     &trans  &trans  &trans  &trans  &trans  &trans                                                                   &trans  &trans  &trans  &trans  &trans  &trans
@@ -101,8 +98,7 @@
             &trans  &trans  &trans  &trans                                                                                   &trans  &trans  &trans  &trans
                                                   &trans  &trans                                        &trans  &trans
                                                           &trans                                        &trans
-                                      &bl BL_TOG  &trans  &trans                                        &trans  &trans  &trans
-    &trans  &trans  &trans
+                                      &out OUT_TOG  &trans  &trans                                        &trans  &trans  &trans
             >;
         };
 


### PR DESCRIPTION
## 🎯 Perfect Synchronization with KLCM

This PR ensures the ZMK config keymap exactly matches the KLCM source of truth configuration.

### ✅ Changes Applied

**Removed ZMK Studio Dependencies**:
- ❌ `&studio_unlock` - Removed Studio unlock binding
- ❌ `&bl BL_TOG` - Removed backlight toggle (Studio feature)
- ❌ `#include <dt-bindings/zmk/backlight.h>` - Removed backlight include

- ✅ `&out OUT_TOG` - Clean Bluetooth/USB output toggle
- ✅ Updated comments for KLCM compatibility

**Layout Cleanup**:
- ❌ Removed extra ESC key bindings for cleaner layout
- ✅ Maintained all essential keyboard functionality
- ✅ Preserved 3-layer structure (Default, Keypad, System)

### 🔄 Synchroniz### 🔄 Synchroniz### 🔄 Synchroniz### 🔄 Synch dependencies that KLCM removed
**After**: Perfect match between both repositories

**KLCM Source**: `configs/zmk_adv_mod/adv_mod.keymap`
**ZMK Config**: `config/adv_mod.keymap` ✅ **Now identical**

### 🚀 Benefits

- **Clean Builds**: No Studio dependencies means lighter firmware
- **KLCM Compatible**: Perfect synchronization with mapper tool
- **Production Ready**: Stable bindings, no experimental features

### 📋 Validation

- ✅ Keymap syntax valid for ZMK- ✅ Keymap syntax valid for ZMK- ✅ Keymap syntax valid for ZMK- ✅ Keytion from Studio features
- ✅ Maintai- ✅ Maintai- ✅ Maintai- ✅ Maintai- ✅ Maintai- ✅e into cheyo branch! 🎉**