### PR TITLE
fix: Use cmake-args to specify custom keymap file

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,5 +7,6 @@
 include:
   - board: nice_nano_v2
     shield: pillzmod_pro
+    cmake-args: -DKEYMAP_FILE=${ZMK_CONFIG}/adv_mod.keymap
   - board: nice_nano_v2
     shield: settings_reset


### PR DESCRIPTION
## Problem
The ZMK build was not picking up the customized keymap from `config/adv_mod.keymap`.

## Root Cause
ZMK by default looks for a keymap file matching the shield name (`pillzmod_pro.keymap`).

## Solution
Use the `-DKEYMAP_FILE` cmake argument in `build.yaml` to explicitly tell ZMK to use `config/adv_mod.keymap`.

This is cleaner than renaming the file since it keeps the original filename and makes it explicit which keymap is being used.